### PR TITLE
Prevent empty `Link` headers

### DIFF
--- a/lib/clean_pagination.rb
+++ b/lib/clean_pagination.rb
@@ -78,7 +78,7 @@ module CleanPagination
       links << "<#{request.url}>; rel=\"first\"; items=\"0-#{suppress_infinity(requested_limit-1)}\""
     end
 
-    headers['Link'] = links.join ', '
+    headers['Link'] = links.join ', ' unless links.empty?
   end
 
   private

--- a/test/clean_pagination_test.rb
+++ b/test/clean_pagination_test.rb
@@ -369,4 +369,12 @@ class ApplicationControllerTest < ActionController::TestCase
       assert_match /\?foo=bar/, link
     end
   end
+
+  test "omits empty link header" do
+    @controller.stubs(:total_items).returns 2
+
+    get :index
+
+    assert_equal false, response.headers.has_key?('Link')
+  end
 end


### PR DESCRIPTION
Currently the response headers will include `Link:` no matter what -
even if there are no links. This patch only sets the header if there are
links to include.
