### PR TITLE
make rendering, raising of errors optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ class ApplicationController < ActionController::Base
       render json: (offset...offset+limit).to_a
     end
   end
+  
+  # Using optional settings
+  def options
+    begin
+      paginate Foo.scope.count, max_per_page, allow_render: false, raise_errors: true do |limit, offset|
+        respond_with Foo.scope.limit(limit).offset(offset)
+      end
+    rescue RangeError
+      render json: { error: { message: "invalid pagination range" } }
+    end
+  end
 end
 ```
 
@@ -44,6 +55,14 @@ end
 * **Semantic HTTP.** Built in strict conformance to RFCs 2616 and 5988.
 
 ### Under the hood
+
+To prevent this gem from rendering while still allowing it to set
+headers and response codes, pass `allow_render: false` to `paginate`.
+This may be used to avoid `DoubleRenderError` situations.
+
+To handle the invalid request range condition in your app, pass the
+`raise_errors: true` option.  This will raise a `RangeError` which you can
+rescue (and thus control what is rendered).  Headers will still be set.
 
 [TODO: explain what the headers mean.] Until this is written you can consult
 the tests for an idea how it works, or use a client that is compatible, such as

--- a/lib/clean_pagination.rb
+++ b/lib/clean_pagination.rb
@@ -1,6 +1,6 @@
 module CleanPagination
 
-  def paginate total_items, max_range_size
+  def paginate total_items, max_range_size, render_errors: true, raise_errors: false
     headers['Accept-Ranges'] = 'items'
     headers['Range-Unit'] = 'items'
 
@@ -17,8 +17,12 @@ module CleanPagination
        (requested_from > 0 && requested_from >= total_items)
       response.status = 416
       headers['Content-Range'] = "*/#{total_items}"
-      render text: 'invalid pagination range'
-      return
+      message = 'invalid pagination range'
+      raise RangeError, message if raise_errors
+      if render_errors
+        render text: message
+        return
+      end
     end
 
     available_to = [requested_to,
@@ -30,7 +34,7 @@ module CleanPagination
     if available_limit == 0
       headers['Content-Range'] = "*/0"
       response.status = 204
-      render text: ''
+      render text: '' if render_errors
       return
     end
 

--- a/lib/clean_pagination.rb
+++ b/lib/clean_pagination.rb
@@ -1,6 +1,9 @@
 module CleanPagination
 
-  def paginate total_items, max_range_size, render_errors: true, raise_errors: false
+  def paginate total_items, max_range_size, options = {}
+    options[:allow_render] ||= true
+    options[:raise_errors] ||= false
+
     headers['Accept-Ranges'] = 'items'
     headers['Range-Unit'] = 'items'
 
@@ -18,8 +21,8 @@ module CleanPagination
       response.status = 416
       headers['Content-Range'] = "*/#{total_items}"
       message = 'invalid pagination range'
-      raise RangeError, message if raise_errors
-      if render_errors
+      raise RangeError, message if options[:raise_errors]
+      if options[:allow_render]
         render text: message
         return
       end
@@ -34,7 +37,7 @@ module CleanPagination
     if available_limit == 0
       headers['Content-Range'] = "*/0"
       response.status = 204
-      render text: '' if render_errors
+      render text: '' if options[:allow_render]
       return
     end
 

--- a/lib/clean_pagination.rb
+++ b/lib/clean_pagination.rb
@@ -1,7 +1,7 @@
 module CleanPagination
 
   def paginate total_items, max_range_size, options = {}
-    options[:allow_render] ||= true
+    options[:allow_render] = true if options[:allow_render].nil?
     options[:raise_errors] ||= false
 
     headers['Accept-Ranges'] = 'items'

--- a/test/clean_pagination_test.rb
+++ b/test/clean_pagination_test.rb
@@ -123,6 +123,27 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_equal '*/101', response.headers['Content-Range']
   end
 
+  test "optionally raise exception when range is invalid" do
+    @request.headers['Range-Unit'] = 'items'
+    @request.headers['Range'] = "1-0"
+    @controller.stubs(:raise_errors).returns true
+
+    @controller.expects(:action).never
+    assert_raises(RangeError) do
+      get :index
+    end
+  end
+
+  test "optionally prevent rendering anything when range is invalid" do
+    @request.headers['Range-Unit'] = 'items'
+    @request.headers['Range'] = "1-0"
+    @controller.stubs(:allow_render).returns false
+    @controller.expects(:action).never
+    assert_raises(ActionView::MissingTemplate) do
+      get :index
+    end
+  end
+
   test "allows one-item requests" do
     @request.headers['Range-Unit'] = 'items'
     @request.headers['Range'] = "0-0"

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -6,10 +6,20 @@ class ApplicationController < ActionController::Base
   include CleanPagination
 
   def index
-    paginate total_items, max_range do |limit, offset|
+    paginate total_items, max_range,
+      allow_render: allow_render, raise_errors: raise_errors do |limit, offset|
+
       action limit, offset
       render json: [limit, offset], status: index_status
     end
+  end
+
+  def allow_render
+    true # stub me
+  end
+
+  def raise_errors
+    false # stub me
   end
 
   def total_items


### PR DESCRIPTION
Rendering here can cause frustrating DoubleRenderError exceptions, plus some applications may want to handle the edge cases differently.  This change preserves the old behavior by default and adds two keyword arguments: `render_errors` controls whether or not text is rendered when the requested range is invalid and `raise_errors` controls whether or not an exception should be raised instead, in which case a generic `RangeError` is raised.

Although it is technically not an error, removing all instances of "render" from this gem is desirable, so the `render_errors` option also applies to the "no content" case as well.