### PR TITLE
Allow user code to handle empty responses

### DIFF
--- a/lib/clean_pagination.rb
+++ b/lib/clean_pagination.rb
@@ -22,10 +22,8 @@ module CleanPagination
       headers['Content-Range'] = "*/#{total_items}"
       message = 'invalid pagination range'
       raise RangeError, message if options[:raise_errors]
-      if options[:allow_render]
-        render text: message
-        return
-      end
+      render text: message if options[:allow_render]
+      return
     end
 
     available_to = [requested_to,
@@ -36,18 +34,15 @@ module CleanPagination
 
     if available_limit == 0
       headers['Content-Range'] = "*/0"
-      response.status = 204
-      render text: '' if options[:allow_render]
-      return
+    else
+      headers['Content-Range'] = "#{
+          requested_from
+        }-#{
+          available_to
+        }/#{
+          total_items < Float::INFINITY ? total_items : '*'
+        }"
     end
-
-    headers['Content-Range'] = "#{
-        requested_from
-      }-#{
-        available_to
-      }/#{
-        total_items < Float::INFINITY ? total_items : '*'
-      }"
 
     yield available_limit, requested_from
     if available_limit < total_items && response.status == 200

--- a/lib/clean_pagination/version.rb
+++ b/lib/clean_pagination/version.rb
@@ -1,3 +1,3 @@
 module CleanPagination
-  VERSION = "0.0.9"
+  VERSION = "1.0.0"
 end

--- a/test/clean_pagination_test.rb
+++ b/test/clean_pagination_test.rb
@@ -83,23 +83,15 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_equal '*/101', response.headers['Content-Range']
   end
 
-  test "accepts a range starting from 0 when there are no items" do
+  test "returns 200 when no items found, delegates response to action" do
     @controller.stubs(:total_items).returns 0
     @request.headers['Range-Unit'] = 'items'
     @request.headers['Range'] = "0-9"
 
-    @controller.expects(:action).never
+    @controller.expects(:action).with(0, 0)
     get :index
-    assert_equal 204, response.status
+    assert_equal 200, response.status
     assert_equal '*/0', response.headers['Content-Range']
-  end
-
-  test "returns empty body when there are zero total items" do
-    @controller.stubs(:total_items).returns 0
-    @controller.expects(:action).never
-    get :index
-    assert_equal 204, response.status
-    assert_equal "", response.body
   end
 
   test "refuses a range with nonzero start when there are no items" do
@@ -387,7 +379,7 @@ class ApplicationControllerTest < ActionController::TestCase
     get :index, foo: 'bar'
 
     response.headers['Link'].scan(/<[^>]+>/).each do |link|
-      assert_match /\?foo=bar/, link
+      assert_match(/\?foo=bar/, link)
     end
   end
 

--- a/test/clean_pagination_test.rb
+++ b/test/clean_pagination_test.rb
@@ -146,6 +146,18 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_equal '0-0/101', response.headers['Content-Range']
   end
 
+  test "allows one-item responses" do
+    @request.headers['Range-Unit'] = 'items'
+    @request.headers['Range'] = "0-9"
+    @controller.stubs(:total_items).returns 1
+    @controller.stubs(:max_range).returns 100
+
+    @controller.expects(:action).with(1, 0)
+    get :index
+    assert_equal 200, response.status
+    assert_equal '0-0/1', response.headers['Content-Range']
+  end
+
   test "handles ranges beyond collection length via truncation" do
     @request.headers['Range-Unit'] = 'items'
     @request.headers['Range'] = "50-200"


### PR DESCRIPTION
This avoids special logic in the client for handling a blank body rather than JSON `[]`.
