### PR TITLE
Global config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - 2.2
+sudo: false

--- a/lib/clean_pagination.rb
+++ b/lib/clean_pagination.rb
@@ -2,7 +2,8 @@ module CleanPagination
   class << self
     DEFAULT_CONFIG = OpenStruct.new({
       allow_render: true,
-      raise_errors: false
+      raise_errors: false,
+      invalid_message: 'invalid pagination range'
     })
 
     def setup
@@ -33,9 +34,8 @@ module CleanPagination
        (requested_from > 0 && requested_from >= total_items)
       response.status = 416
       headers['Content-Range'] = "*/#{total_items}"
-      message = 'invalid pagination range'
-      raise RangeError, message if options[:raise_errors]
-      render text: message if options[:allow_render]
+      raise RangeError, options[:invalid_message] if options[:raise_errors]
+      render text: options[:invalid_message] if options[:allow_render]
       return
     end
 

--- a/lib/clean_pagination.rb
+++ b/lib/clean_pagination.rb
@@ -1,8 +1,21 @@
 module CleanPagination
+  class << self
+    DEFAULT_CONFIG = OpenStruct.new({
+      allow_render: true,
+      raise_errors: false
+    })
+
+    def setup
+      yield config
+    end
+
+    def config
+      @__config__ ||= DEFAULT_CONFIG.dup
+    end
+  end
 
   def paginate total_items, max_range_size, options = {}
-    options[:allow_render] = true if options[:allow_render].nil?
-    options[:raise_errors] ||= false
+    options = CleanPagination::config.to_h.merge(options)
 
     headers['Accept-Ranges'] = 'items'
     headers['Range-Unit'] = 'items'


### PR DESCRIPTION
Allows accessing setup configuration from one global location (e.g. initializer). Global settings can be overridden in `paginate` call.
